### PR TITLE
追加: テーマ・共通スタイルを定義 (#2)

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/shared/theme/app_colors.dart';
 import 'package:go_router/go_router.dart';
 
-/// アプリのルート定義
-/// 画面遷移のルートをすべてここで管理する
+// アプリのルート定義
+// 画面遷移のルートをすべてここで管理する
 final _router = GoRouter(
   initialLocation: '/',
   routes: [
@@ -39,6 +40,15 @@ class App extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return MaterialApp.router(title: '昆虫食初心者ガイド', routerConfig: _router);
+    return MaterialApp.router(
+      title: '昆虫食初心者ガイド',
+      routerConfig: _router,
+      theme: ThemeData(
+        // メインカラーをAppColors.primaryから自動生成
+        colorScheme: ColorScheme.fromSeed(seedColor: AppColors.primary),
+        // 全画面の背景色をAppColors.backgroundに統一
+        scaffoldBackgroundColor: AppColors.background,
+      ),
+    );
   }
 }

--- a/lib/shared/theme/app_colors.dart
+++ b/lib/shared/theme/app_colors.dart
@@ -1,0 +1,33 @@
+import 'package:flutter/material.dart';
+
+/// アプリ全体で使用するカラー定数
+class AppColors {
+  AppColors._(); // インスタンス化を禁止する
+
+  /// メインカラー（ボタン・アイコン・プログレスバー）
+  static const Color primary = Color(0xFF3D9970);
+
+  /// メインカラーの薄い版（背景・バッジ・コメントボックス）
+  static const Color primaryLight = Color(0xFFF0FAF7);
+
+  /// 画面全体の背景色
+  static const Color background = Color(0xFFF0FAF7);
+
+  /// メインテキスト（見出し・質問文）
+  static const Color textPrimary = Color(0xFF1A2E2A);
+
+  /// サブテキスト（説明文・ローディングテキスト）
+  static const Color textSecondary = Color(0xFF555F6E);
+
+  /// タグのテキスト色
+  static const Color tagText = Color(0xFF2D7A5F);
+
+  /// 難易度★の塗り色
+  static const Color starFilled = Color(0xFFF5C518);
+
+  /// 難易度★の空色
+  static const Color starEmpty = Color(0xFFD1D5DB);
+
+  /// 「いいえ」ボタンなどのセカンダリボタン背景
+  static const Color buttonSecondary = Color(0xFFEEEEEE);
+}

--- a/lib/shared/theme/app_text_styles.dart
+++ b/lib/shared/theme/app_text_styles.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'app_colors.dart';
+
+/// アプリ全体で使用するテキストスタイル定数
+class AppTextStyles {
+  AppTextStyles._(); // インスタンス化を禁止する
+
+  /// 大見出し（画面タイトルなど）
+  static const TextStyle headline = TextStyle(
+    fontSize: 24,
+    fontWeight: FontWeight.bold,
+    color: AppColors.textPrimary,
+  );
+
+  /// 中見出し（セクションタイトルなど）
+  static const TextStyle subheadline = TextStyle(
+    fontSize: 18,
+    fontWeight: FontWeight.bold,
+    color: AppColors.textPrimary,
+  );
+
+  /// 本文
+  static const TextStyle body = TextStyle(
+    fontSize: 14,
+    fontWeight: FontWeight.normal,
+    color: AppColors.textPrimary,
+  );
+
+  /// キャプション（補足テキスト・ローディングテキストなど）
+  static const TextStyle caption = TextStyle(
+    fontSize: 12,
+    fontWeight: FontWeight.normal,
+    color: AppColors.textSecondary,
+  );
+}

--- a/lib/shared/widgets/difficulty_stars.dart
+++ b/lib/shared/widgets/difficulty_stars.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import '../theme/app_colors.dart';
+
+/// 難易度を★で表示するウィジェット
+/// difficulty: 1〜5の整数を受け取る
+class DifficultyStars extends StatelessWidget {
+  final int difficulty;
+
+  const DifficultyStars({super.key, required this.difficulty});
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      mainAxisSize: MainAxisSize.min,
+      children: List.generate(5, (index) {
+        return Icon(
+          Icons.star,
+          size: 16,
+          color: index < difficulty
+              ? AppColors.starFilled
+              : AppColors.starEmpty,
+        );
+      }),
+    );
+  }
+}


### PR DESCRIPTION
## 概要

Issue #2 のテーマ・共通スタイルを定義した。アプリ全体のカラー・テキストスタイルを一箇所に集約し、デザインの一貫性を確保した。あわせて難易度★ウィジェットを実装した。

## 関連 Issue

Closes #2

## 変更の種類

- [x] 新機能（`追加`）

## 変更内容の詳細

- `lib/shared/theme/app_colors.dart` を作成（プライマリカラーなど9色を定義）
- `lib/shared/theme/app_text_styles.dart` を作成（見出し・本文・キャプションのTextStyle定義）
- `lib/shared/widgets/difficulty_stars.dart` を作成（難易度1〜5を★で表示するウィジェット）
- `lib/app.dart` に `ThemeData` を追加（メインカラー・背景色を適用）

## 動作確認

- [x] `flutter analyze` でエラー・警告が出ない
- [x] `flutter run` でテーマが適用された状態でアプリが起動する
- [x] `DifficultyStars(difficulty: 3)` を仮置きして★3つが正しく表示される

## レビュアーへのメモ

カラーはBoltのプロトタイプのスクリーンショットから抽出した値を使用。微調整が必要な場合は `app_colors.dart` の1箇所を修正するだけで全画面に反映される。