### PR TITLE
診断フロー画面を実装

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:frontend/features/diagnosis/pages/diagnosis_page.dart';
 import 'package:frontend/features/insects/pages/insects_list_page.dart';
 import 'package:frontend/features/insects/pages/insect_detail_page.dart';
 import 'package:frontend/shared/theme/app_colors.dart';
@@ -16,8 +17,7 @@ final _router = GoRouter(
     ),
     GoRoute(
       path: '/diagnosis',
-      builder: (context, state) =>
-          const Scaffold(body: Center(child: Text('診断フロー画面'))),
+      builder: (context, state) => const DiagnosisPage(),
     ),
     GoRoute(
       path: '/diagnosis/result',

--- a/lib/features/diagnosis/pages/diagnosis_page.dart
+++ b/lib/features/diagnosis/pages/diagnosis_page.dart
@@ -1,0 +1,264 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:frontend/features/diagnosis/providers/diagnosis_provider.dart';
+import 'package:frontend/shared/theme/app_colors.dart';
+import 'package:go_router/go_router.dart';
+
+class DiagnosisPage extends ConsumerWidget {
+  const DiagnosisPage({super.key});
+
+  String _getCategoryEmoji(String category) {
+    switch (category) {
+      case 'visual':
+        return '👁';
+      case 'physical':
+        return '🤚';
+      case 'mental':
+        return '💪';
+      default:
+        return '❓';
+    }
+  }
+
+  String _getCategoryLabel(String category) {
+    switch (category) {
+      case 'visual':
+        return '見た目への耐性';
+      case 'physical':
+        return '食べる勇気';
+      case 'mental':
+        return '挑戦する気持ち';
+      default:
+        return '';
+    }
+  }
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final diagnosis = ref.watch(diagnosisStateProvider);
+
+    if (diagnosis.isLoading) {
+      return Scaffold(
+        backgroundColor: AppColors.background,
+        body: const Center(
+          child: CircularProgressIndicator(),
+        ),
+      );
+    }
+
+    if (diagnosis.error != null) {
+      return Scaffold(
+        backgroundColor: AppColors.background,
+        body: Center(
+          child: Text('エラーが発生しました: ${diagnosis.error}'),
+        ),
+      );
+    }
+
+    if (diagnosis.questions.isEmpty) {
+      return Scaffold(
+        backgroundColor: AppColors.background,
+        body: const Center(
+          child: Text('質問が取得できませんでした'),
+        ),
+      );
+    }
+
+    final currentQuestion = diagnosis.questions[diagnosis.currentQuestion - 1];
+    final progressPercentage = (diagnosis.currentQuestion / 6 * 100).toInt();
+
+    return Scaffold(
+      backgroundColor: AppColors.background,
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 24),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                // 進捗表示
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      '質問${diagnosis.currentQuestion}/6',
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: Colors.black87,
+                      ),
+                    ),
+                    Text(
+                      '$progressPercentage%',
+                      style: const TextStyle(
+                        fontSize: 14,
+                        fontWeight: FontWeight.w500,
+                        color: Colors.black87,
+                      ),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+
+                // プログレスバー
+                ClipRRect(
+                  borderRadius: BorderRadius.circular(4),
+                  child: LinearProgressIndicator(
+                    value: diagnosis.currentQuestion / 6,
+                    minHeight: 6,
+                    backgroundColor: Colors.grey.withAlpha(77),
+                    valueColor: AlwaysStoppedAnimation<Color>(
+                      AppColors.primary,
+                    ),
+                  ),
+                ),
+                const SizedBox(height: 32),
+
+                // 質問カード
+                Container(
+                  padding: const EdgeInsets.all(24),
+                  decoration: BoxDecoration(
+                    color: AppColors.white,
+                    borderRadius: BorderRadius.circular(12),
+                    boxShadow: [
+                      BoxShadow(
+                        color: Colors.black.withAlpha(25),
+                        blurRadius: 8,
+                        offset: const Offset(0, 2),
+                      ),
+                    ],
+                  ),
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      // カテゴリラベル
+                      Container(
+                        padding: const EdgeInsets.symmetric(
+                          horizontal: 12,
+                          vertical: 6,
+                        ),
+                        decoration: BoxDecoration(
+                          color: AppColors.primaryLight,
+                          borderRadius: BorderRadius.circular(20),
+                        ),
+                        child: Row(
+                          mainAxisSize: MainAxisSize.min,
+                          children: [
+                            Text(
+                              _getCategoryEmoji(currentQuestion.category),
+                              style: const TextStyle(fontSize: 16),
+                            ),
+                            const SizedBox(width: 6),
+                            Text(
+                              _getCategoryLabel(currentQuestion.category),
+                              style: const TextStyle(
+                                fontSize: 12,
+                                fontWeight: FontWeight.w500,
+                                color: Colors.black87,
+                              ),
+                            ),
+                          ],
+                        ),
+                      ),
+                      const SizedBox(height: 24),
+
+                      // 質問文
+                      Text(
+                        currentQuestion.body,
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.black87,
+                          height: 1.5,
+                        ),
+                      ),
+                      const SizedBox(height: 32),
+
+                      // はい/いいえボタン
+                      Row(
+                        children: [
+                          // はいボタン
+                          Expanded(
+                            child: ElevatedButton(
+                              onPressed: () {
+                                ref
+                                    .read(diagnosisStateProvider.notifier)
+                                    .answerQuestion(1);
+
+                                if (diagnosis.currentQuestion == 6) {
+                                  context.push('/diagnosis/result');
+                                } else {
+                                  ref
+                                      .read(diagnosisStateProvider.notifier)
+                                      .nextQuestion();
+                                }
+                              },
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: AppColors.primary,
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 16,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                              ),
+                              child: const Text(
+                                'はい',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                          const SizedBox(width: 12),
+
+                          // いいえボタン
+                          Expanded(
+                            child: ElevatedButton(
+                              onPressed: () {
+                                ref
+                                    .read(diagnosisStateProvider.notifier)
+                                    .answerQuestion(0);
+
+                                if (diagnosis.currentQuestion == 6) {
+                                  context.push('/diagnosis/result');
+                                } else {
+                                  ref
+                                      .read(diagnosisStateProvider.notifier)
+                                      .nextQuestion();
+                                }
+                              },
+                              style: ElevatedButton.styleFrom(
+                                backgroundColor: Colors.grey.withAlpha(77),
+                                padding: const EdgeInsets.symmetric(
+                                  vertical: 16,
+                                ),
+                                shape: RoundedRectangleBorder(
+                                  borderRadius: BorderRadius.circular(8),
+                                ),
+                              ),
+                              child: const Text(
+                                'いいえ',
+                                style: TextStyle(
+                                  fontSize: 16,
+                                  fontWeight: FontWeight.bold,
+                                  color: Colors.white,
+                                ),
+                              ),
+                            ),
+                          ),
+                        ],
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/diagnosis/providers/diagnosis_provider.dart
+++ b/lib/features/diagnosis/providers/diagnosis_provider.dart
@@ -1,0 +1,131 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:frontend/features/questions/models/question.dart';
+import 'package:frontend/features/questions/repositories/question_repository.dart';
+import 'package:frontend/shared/api/api_client.dart';
+
+class DiagnosisState {
+  final int currentQuestion;
+  final List<Question> questions;
+  final List<int> answers;
+  final Map<String, int> categoryScores;
+  final bool isLoading;
+  final String? error;
+
+  DiagnosisState({
+    required this.currentQuestion,
+    required this.questions,
+    required this.answers,
+    required this.categoryScores,
+    required this.isLoading,
+    this.error,
+  });
+
+  DiagnosisState copyWith({
+    int? currentQuestion,
+    List<Question>? questions,
+    List<int>? answers,
+    Map<String, int>? categoryScores,
+    bool? isLoading,
+    String? error,
+  }) {
+    return DiagnosisState(
+      currentQuestion: currentQuestion ?? this.currentQuestion,
+      questions: questions ?? this.questions,
+      answers: answers ?? this.answers,
+      categoryScores: categoryScores ?? this.categoryScores,
+      isLoading: isLoading ?? this.isLoading,
+      error: error ?? this.error,
+    );
+  }
+}
+
+class DiagnosisStateNotifier extends StateNotifier<DiagnosisState> {
+  final QuestionRepository _repository;
+
+  DiagnosisStateNotifier(this._repository)
+      : super(DiagnosisState(
+          currentQuestion: 1,
+          questions: [],
+          answers: [0, 0, 0, 0, 0, 0],
+          categoryScores: {'visual': 0, 'physical': 0, 'mental': 0},
+          isLoading: true,
+        )) {
+    _loadQuestions();
+  }
+
+  Future<void> _loadQuestions() async {
+    try {
+      final questions = await _repository.getQuestions();
+      state = state.copyWith(
+        questions: questions,
+        isLoading: false,
+      );
+    } catch (e) {
+      state = state.copyWith(
+        error: e.toString(),
+        isLoading: false,
+      );
+    }
+  }
+
+  void answerQuestion(int answer) {
+    final newAnswers = [...state.answers];
+    newAnswers[state.currentQuestion - 1] = answer;
+
+    final newScores = _calculateCategoryScores(newAnswers);
+
+    state = state.copyWith(
+      answers: newAnswers,
+      categoryScores: newScores,
+    );
+  }
+
+  void nextQuestion() {
+    if (state.currentQuestion < 6) {
+      state = state.copyWith(
+        currentQuestion: state.currentQuestion + 1,
+      );
+    }
+  }
+
+  void previousQuestion() {
+    if (state.currentQuestion > 1) {
+      state = state.copyWith(
+        currentQuestion: state.currentQuestion - 1,
+      );
+    }
+  }
+
+  void reset() {
+    state = DiagnosisState(
+      currentQuestion: 1,
+      questions: state.questions,
+      answers: [0, 0, 0, 0, 0, 0],
+      categoryScores: {'visual': 0, 'physical': 0, 'mental': 0},
+      isLoading: false,
+    );
+  }
+
+  Map<String, int> _calculateCategoryScores(List<int> answers) {
+    final scores = {'visual': 0, 'physical': 0, 'mental': 0};
+
+    for (final (index, answer) in answers.indexed) {
+      if (index < state.questions.length) {
+        final category = state.questions[index].category;
+        scores[category] = (scores[category] ?? 0) + answer;
+      }
+    }
+
+    return scores;
+  }
+}
+
+final questionRepositoryProvider = Provider<QuestionRepository>((ref) {
+  return QuestionRepository(ApiClient());
+});
+
+final diagnosisStateProvider =
+    StateNotifierProvider<DiagnosisStateNotifier, DiagnosisState>((ref) {
+  final repository = ref.watch(questionRepositoryProvider);
+  return DiagnosisStateNotifier(repository);
+});

--- a/lib/features/questions/models/question.dart
+++ b/lib/features/questions/models/question.dart
@@ -1,0 +1,19 @@
+class Question {
+  final int id;
+  final String body;
+  final String category;
+
+  Question({
+    required this.id,
+    required this.body,
+    required this.category,
+  });
+
+  factory Question.fromJson(Map<String, dynamic> json) {
+    return Question(
+      id: json['id'],
+      body: json['body'],
+      category: json['category'],
+    );
+  }
+}

--- a/lib/features/questions/repositories/question_repository.dart
+++ b/lib/features/questions/repositories/question_repository.dart
@@ -1,0 +1,15 @@
+import 'package:frontend/shared/api/api_client.dart';
+
+import '../models/question.dart';
+import 'question_repository_interface.dart';
+
+class QuestionRepository implements IQuestionRepository {
+  final ApiClient _apiClient;
+
+  QuestionRepository(this._apiClient);
+
+  @override
+  Future<List<Question>> getQuestions() async {
+    return await _apiClient.getQuestions();
+  }
+}

--- a/lib/features/questions/repositories/question_repository_interface.dart
+++ b/lib/features/questions/repositories/question_repository_interface.dart
@@ -1,0 +1,5 @@
+import '../models/question.dart';
+
+abstract class IQuestionRepository {
+  Future<List<Question>> getQuestions();
+}

--- a/lib/shared/api/api_client.dart
+++ b/lib/shared/api/api_client.dart
@@ -1,6 +1,7 @@
 import 'package:dio/dio.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:frontend/features/insects/models/insect.dart';
+import 'package:frontend/features/questions/models/question.dart';
 
 class ApiClient {
   static late final Dio _dio;
@@ -25,5 +26,12 @@ class ApiClient {
   Future<Insect> getInsectById(int id) async {
     final response = await _dio.get('/insects/$id');
     return Insect.fromJson(response.data);
+  }
+
+  Future<List<Question>> getQuestions() async {
+    final response = await _dio.get('/questions');
+    return (response.data as List)
+        .map((json) => Question.fromJson(json))
+        .toList();
   }
 }


### PR DESCRIPTION
## 概要

Issue #5 の診断フロー画面を実装しました。6問の質問をはい/いいえで回答し、カテゴリ別（visual/physical/mental）にスコアを蓄積します。

## 関連 Issue

Closes #5

## 変更の種類

- [x] 新機能（`追加`）
- [ ] バグ修正（`修正`）
- [ ] 既存機能の改善（`更新`）
- [ ] リファクタリング（動作変更なし）
- [ ] ドキュメント
- [ ] テスト

## 変更内容の詳細

- `lib/features/questions/models/question.dart` - Question モデル定義
- `lib/features/questions/repositories/question_repository_interface.dart` - IQuestionRepository 抽象クラス
- `lib/features/questions/repositories/question_repository.dart` - API実装
- `lib/features/diagnosis/providers/diagnosis_provider.dart` - 診断状態管理（Riverpod）
- `lib/features/diagnosis/pages/diagnosis_page.dart` - 診断フロー画面UI
- `lib/shared/api/api_client.dart` - getQuestions() メソッド追加
- `lib/app.dart` - /diagnosis ルート設定

## 動作確認

- [x] `flutter analyze` でエラー・警告が出ない
- [x] `flutter run` でアプリが起動する
- [x] 診断フロー画面が正しく表示される
- [x] 質問リストが取得されて表示される
- [x] はい/いいえボタンでスコア加算される

## レビュアーへのメモ

- Riverpod StateNotifierProvider で診断状態を一元管理
- カテゴリ別スコア計算は自動的に行われます
- 6問回答完了後は /diagnosis/result へ遷移（結果画面はIssue #6で実装予定）